### PR TITLE
sm6375-common: fix broken link /vendor/app/CneApp/lib/arm64/libvndfwk…

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -63,6 +63,7 @@ vendor/lib64/libcneapiclient.so
 vendor/lib64/libcneoplookup.so
 vendor/lib64/libcneqmiutils.so
 vendor/lib64/libjnihelper.so
+vendor/lib64/libvndfwk_detect_jni.qti.so
 vendor/lib64/libwms.so
 vendor/lib64/libwqe.so
 vendor/lib64/libxml.so


### PR DESCRIPTION
…_detect_jni.qti.so, reason for CneApp crash?